### PR TITLE
Replace Registries.BLOCK iteration with RegistryEntryAddedCallback usage

### DIFF
--- a/src/main/java/net/reimaden/arcadiandream/loot/ModEarlyLootTableModifiers.java
+++ b/src/main/java/net/reimaden/arcadiandream/loot/ModEarlyLootTableModifiers.java
@@ -1,0 +1,21 @@
+package net.reimaden.arcadiandream.loot;
+
+import com.google.common.collect.Lists;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+
+public class ModEarlyLootTableModifiers {
+    public static final List<Identifier> LEAVES_LOOT_TABLES = Lists.newArrayList(
+            new Identifier("blocks/acacia_leaves"),
+            new Identifier("blocks/azalea_leaves"),
+            new Identifier("blocks/birch_leaves"),
+            new Identifier("blocks/cherry_leaves"),
+            new Identifier("blocks/dark_oak_leaves"),
+            new Identifier("blocks/flowering_azalea_leaves"),
+            new Identifier("blocks/jungle_leaves"),
+            new Identifier("blocks/mangrove_leaves"),
+            new Identifier("blocks/oak_leaves"),
+            new Identifier("blocks/spruce_leaves")
+    );
+}

--- a/src/main/java/net/reimaden/arcadiandream/loot/ModLootTableModifiers.java
+++ b/src/main/java/net/reimaden/arcadiandream/loot/ModLootTableModifiers.java
@@ -5,7 +5,6 @@
 
 package net.reimaden.arcadiandream.loot;
 
-import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 import net.fabricmc.fabric.api.loot.v2.LootTableEvents;
 import net.minecraft.loot.LootPool;
 import net.minecraft.loot.LootTables;
@@ -20,14 +19,12 @@ import net.minecraft.loot.provider.number.UniformLootNumberProvider;
 import net.minecraft.predicate.NumberRange;
 import net.minecraft.predicate.entity.LocationPredicate;
 import net.minecraft.predicate.item.ItemPredicate;
-import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.biome.BiomeKeys;
 import net.reimaden.arcadiandream.ArcadianDream;
 import net.reimaden.arcadiandream.item.ModItems;
 
-import java.util.ArrayList;
-import java.util.List;
+import static net.reimaden.arcadiandream.loot.ModEarlyLootTableModifiers.LEAVES_LOOT_TABLES;
 
 public class ModLootTableModifiers {
 
@@ -61,14 +58,7 @@ public class ModLootTableModifiers {
     private static final LootCondition.Builder NEEDS_FROZEN_OCEAN_BIOME = LocationCheckLootCondition.builder(LocationPredicate.Builder.create().biome(BiomeKeys.FROZEN_OCEAN));
     private static final LootCondition.Builder NEEDS_DEEP_FROZEN_OCEAN_BIOME = LocationCheckLootCondition.builder(LocationPredicate.Builder.create().biome(BiomeKeys.DEEP_FROZEN_OCEAN));
 
-    private static final List<Identifier> LEAVES_LOOT_TABLES = new ArrayList<>();
-
     public static void modify() {
-        RegistryEntryAddedCallback.event(Registries.BLOCK).register((rawId, id, object) -> {
-            if (id.toString().endsWith("leaves")) {
-                LEAVES_LOOT_TABLES.add(object.getLootTableId());
-            }
-        });
         LootTableEvents.MODIFY.register((resourceManager, lootManager, id, tableBuilder, source) -> {
             LootPool.Builder poolBuilder = LootPool.builder();
 

--- a/src/main/java/net/reimaden/arcadiandream/loot/ModLootTableModifiers.java
+++ b/src/main/java/net/reimaden/arcadiandream/loot/ModLootTableModifiers.java
@@ -5,8 +5,8 @@
 
 package net.reimaden.arcadiandream.loot;
 
+import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 import net.fabricmc.fabric.api.loot.v2.LootTableEvents;
-import net.minecraft.block.Block;
 import net.minecraft.loot.LootPool;
 import net.minecraft.loot.LootTables;
 import net.minecraft.loot.condition.LocationCheckLootCondition;
@@ -21,13 +21,13 @@ import net.minecraft.predicate.NumberRange;
 import net.minecraft.predicate.entity.LocationPredicate;
 import net.minecraft.predicate.item.ItemPredicate;
 import net.minecraft.registry.Registries;
-import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.biome.BiomeKeys;
 import net.reimaden.arcadiandream.ArcadianDream;
 import net.reimaden.arcadiandream.item.ModItems;
 
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ModLootTableModifiers {
 
@@ -61,7 +61,14 @@ public class ModLootTableModifiers {
     private static final LootCondition.Builder NEEDS_FROZEN_OCEAN_BIOME = LocationCheckLootCondition.builder(LocationPredicate.Builder.create().biome(BiomeKeys.FROZEN_OCEAN));
     private static final LootCondition.Builder NEEDS_DEEP_FROZEN_OCEAN_BIOME = LocationCheckLootCondition.builder(LocationPredicate.Builder.create().biome(BiomeKeys.DEEP_FROZEN_OCEAN));
 
+    private static final List<Identifier> LEAVES_LOOT_TABLES = new ArrayList<>();
+
     public static void modify() {
+        RegistryEntryAddedCallback.event(Registries.BLOCK).register((rawId, id, object) -> {
+            if (id.toString().endsWith("leaves")) {
+                LEAVES_LOOT_TABLES.add(object.getLootTableId());
+            }
+        });
         LootTableEvents.MODIFY.register((resourceManager, lootManager, id, tableBuilder, source) -> {
             LootPool.Builder poolBuilder = LootPool.builder();
 
@@ -83,9 +90,8 @@ public class ModLootTableModifiers {
                 tableBuilder.pool(poolBuilderUpgrade.build());
             }
 
-            for (Map.Entry<RegistryKey<Block>, Block> entry : Registries.BLOCK.getEntrySet()) {
-                Block block = entry.getValue();
-                if (entry.getKey().getValue().toString().endsWith("leaves") && block.getLootTableId().equals(id)) {
+            for (Identifier matchingId : LEAVES_LOOT_TABLES) {
+                if (matchingId.equals(id)) {
                     poolBuilder
                             .rolls(ConstantLootNumberProvider.create(1))
                             .conditionally(RandomChanceLootCondition.builder(0.1f))

--- a/src/main/java/net/reimaden/arcadiandream/mixin/BootstrapMixin.java
+++ b/src/main/java/net/reimaden/arcadiandream/mixin/BootstrapMixin.java
@@ -1,0 +1,23 @@
+package net.reimaden.arcadiandream.mixin;
+
+import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
+import net.minecraft.Bootstrap;
+import net.minecraft.registry.Registries;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static net.reimaden.arcadiandream.loot.ModEarlyLootTableModifiers.LEAVES_LOOT_TABLES;
+
+@Mixin(Bootstrap.class)
+public class BootstrapMixin {
+    @Inject(method = "initialize", at = @At(value = "INVOKE", target = "Lnet/minecraft/registry/Registries;bootstrap()V"))
+    private static void initialize(CallbackInfo ci) {
+        RegistryEntryAddedCallback.event(Registries.BLOCK).register((rawId, id, object) -> {
+            if (id.toString().endsWith("leaves") && !id.getNamespace().equals("minecraft")) {
+                LEAVES_LOOT_TABLES.add(object.getLootTableId());
+            }
+        });
+    }
+}

--- a/src/main/resources/arcadiandream.mixins.json
+++ b/src/main/resources/arcadiandream.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "BlockMixin",
+    "BootstrapMixin",
     "DamageEnchantmentMixin",
     "EnchantmentHelperMixin",
     "EnchantmentMixin",


### PR DESCRIPTION
This cuts down world loading time by *nearly two minutes* in my very large Fabric 1.20.1 modpack.

`LEAVES_LOOT_TABLES` has to be in a separate class as to not accidentally classload everything. It also includes Minecraft's leaves by default, since the `RegistryEntryAddedCallback` listener wouldn't pick those up for some reason.

A silly mixin is used in order to make sure the `RegistryEntryAddedCallback` listener is registered *before* all other mods are initialized and start registering their blocks. Blame Fabric for not having a reliable mod loading order.

Tested and working.